### PR TITLE
Expose WAV raw data to consumers

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ ModulationController.prototype = {
         tag.play();
     },
 
-    transcodeWav: function (samples, tag) {
+    getWavPcmObj: function (samples) {
         var pcmData = [];//new Uint8Array(new ArrayBuffer(samples.length * 2));
         for (var i = 0; i < samples.length; i++) {
 
@@ -163,6 +163,18 @@ ModulationController.prototype = {
             rate: this.rate,
             depth: 16
         }).toWav(pcmData);
+        
+        return pcmObj;
+    },
+
+    getRawWavData: function (array, lbr, version) {
+        var rawPcmData = this.transcode(array, lbr, version);
+        var pcmObj = this.getWavPcmObj(rawPcmData);
+        return pcmObj.raw;
+    },
+
+    transcodeWav: function (samples, tag) {
+        var pcmObj = this.getWavPcmObj(samples);
         tag.src = pcmObj.encode();
     },
 


### PR DESCRIPTION
This slightly reorganizes WAV transcoding to expose a `getRawWavData()` function, letting consumers of the modulator export the WAV data to a downloadable file.

This is mainly intended for IE users, for cases where encoding to MP3 is not an option.